### PR TITLE
Add functionality to switch highlight on game details page

### DIFF
--- a/src/GameDetails/GameDetails.js
+++ b/src/GameDetails/GameDetails.js
@@ -11,13 +11,15 @@ class GameDetails extends Component {
     super();
     this.state = {
       condensedGame: "",
-      recap: ""
+      recap: "",
+      bigHighlight: ""
     }
   }
   async componentDidMount() {
     let highlights = await getHighlights(this.props.location.state.id);
     highlights = await this.filterHighlights(highlights);
     this.props.setHighlights(highlights);
+    this.setState({bigHighlight: this.state.condensedGame || this.state.recap || this.props.highlights[0]});
   }
   filterHighlights = (highlights) => {
     highlights = highlights.map(highlight => {
@@ -50,19 +52,24 @@ class GameDetails extends Component {
     }
     return time.join('');
   }
+  changeHighlight = ({id}) => {
+    const bigHighlight = this.props.highlights.find(highlight => highlight.id === id);
+    this.setState({bigHighlight});
+  }
   render() {
-    const {condensedGame, recap} = this.state;
+    const { condensedGame, recap } = this.state;
     const game = this.props.location.state;
-    const bigHighlight = condensedGame || recap || this.props.highlights[0];
     const highlights = this.props.highlights.map(highlight => {
       return <HighlightCard key={highlight.id} highlight={highlight} />
     });
+    const { bigHighlight } = this.state;
+
     return (
       <article className="game-details">
         <div className="game-title-bar">
           <img
             className="game-heading-logo"
-            src={process.env.PUBLIC_URL + `/mlb-logos/${game.awayTeam.name.split(' ').join('')}.svg`}
+            src={ process.env.PUBLIC_URL + `/mlb-logos/${game.awayTeam.name.split(' ').join('')}.svg` }
             alt={`${game.awayTeam.name} logo`}
           />
           <h2 className="game-title-heading"> { game.awayTeam.name.toUpperCase() }</h2>
@@ -70,21 +77,23 @@ class GameDetails extends Component {
           <h2 className="game-title-heading">{ game.homeTeam.name.toUpperCase() }</h2>
           <img
             className="game-heading-logo"
-            src={process.env.PUBLIC_URL + `/mlb-logos/${game.homeTeam.name.split(' ').join('')}.svg`}
-            alt={`${game.awayTeam.name} logo`}
+            src={ process.env.PUBLIC_URL + `/mlb-logos/${game.homeTeam.name.split(' ').join('')}.svg` }
+            alt={ `${game.awayTeam.name} logo` }
           />
         </div>
         <p className="more-highlights-heading">More Highlights:</p>
+
         <section className="big-video-container">
-          {bigHighlight && <HighlightCard key={bigHighlight.id} highlight={bigHighlight} bigVid={true} />}
-          {bigHighlight && <h3 className="big-vid-title">{bigHighlight.title}</h3>}
+          { bigHighlight && <HighlightCard key={bigHighlight.id} highlight={bigHighlight} bigVid={true} /> }
+          { bigHighlight && <h3 className="big-vid-title">{bigHighlight.title}</h3> }
         </section>
+
         <div className="scroll-container">
           <img className="scroll-up-arrow" src={process.env.PUBLIC_URL + `/arrow.png`} alt="scroll up" />
-          <section className="highlight-container" onClick={(e) => console.log(e.target)}>
-            {condensedGame.id && <HighlightCard key={condensedGame.id} highlight={condensedGame} />}
-            {recap.id && <HighlightCard key={recap.id} highlight={recap} />}
-            {highlights}
+          <section className="highlight-container" onClick={(e) => this.changeHighlight(e.target)}>
+            { condensedGame.id && <HighlightCard key={condensedGame.id} highlight={condensedGame} /> }
+            { recap.id && <HighlightCard key={recap.id} highlight={recap} /> }
+            { highlights }
             <h3 align="center">End of List</h3>
           </section>
           <img className="scroll-down-arrow" src={process.env.PUBLIC_URL + `/arrow.png`} alt="scroll down" />

--- a/src/GameDetails/GameDetails.scss
+++ b/src/GameDetails/GameDetails.scss
@@ -30,6 +30,7 @@
   font-size: 1.8vw;
   font-weight: 400;
   margin: 0;
+  text-shadow: 3px 2px 2px #1f2833;
 }
 
 .score-text {


### PR DESCRIPTION
#### What's this PR do?
- Added a changeHighlight function in the Game Details class to change the main big video when a user clicks on the highlight thumbnail
- changeHighlight grabs that thumbnail's highlight card ID and finds that highlight in the store and sets it to the Game Details component state which loads it in the big video container

#### How should this be manually tested?
Go to a game details page and click on the little thumbnails in the highlight container and it should load that highlight in the main big video container

#### What are the relevant tickets?
Closes #10

#### Future Implementation Plans:
- Add functionality to allow user to select the date of games container / game card population
- Add functionality to allow user to login and select favorite team and favorite highlights
- Testing API Calls

#### Questions/Comments:
